### PR TITLE
Add support for grouping expressions with parentheses

### DIFF
--- a/dotnet/flx.SILQ.Tests/InterpreterTests.cs
+++ b/dotnet/flx.SILQ.Tests/InterpreterTests.cs
@@ -293,5 +293,43 @@ public class InterpreterTests
         // Act & Assert
         Assert.ThrowsException<RuntimeError>(() => interpreter.Interpret(expr));
     }
+
+    [TestMethod]
+    public void Interpret_WhenComplexEqual_ReturnsTrue()
+    {
+        // Arrange 165 == (86 + 79)
+        var left = new Literal(165.0);
+        var right = new Binary(new Literal(86.0), new Token(TokenType.PLUS, "+", null, 1), new Literal(79.0)); // 86 + 79
+        var op = new Token(TokenType.EQUAL_EQUAL, "==", null, 1);
+        var expr = new Binary(left, op, right);
+        var interpreter = new Interpreter();
+
+        // Act
+        var result = interpreter.Interpret(expr);
+
+        // Assert
+        Assert.AreEqual("true", result);
+    }
+
+    [TestMethod]
+    public void Interpret_WhenNestedExpressions_ReturnsResult()
+    {
+        // Arrange
+        var innerLeft = new Literal(2.0);
+        var innerRight = new Literal(3.0);
+        var innerOp = new Token(TokenType.PLUS, "+", null, 1);
+        var innerExpr = new Binary(innerLeft, innerOp, innerRight);
+
+        var outerLeft = new Literal(5.0);
+        var outerOp = new Token(TokenType.EQUAL_EQUAL, "==", null, 1);
+        var expr = new Binary(outerLeft, outerOp, innerExpr);
+        var interpreter = new Interpreter();
+
+        // Act
+        var result = interpreter.Interpret(expr);
+
+        // Assert
+        Assert.AreEqual("true", result);
+    }
 }
 

--- a/dotnet/flx.SILQ.Tests/TokenizerTests.cs
+++ b/dotnet/flx.SILQ.Tests/TokenizerTests.cs
@@ -17,6 +17,8 @@ public class TokenizerTests
     [DataRow("<", TokenType.LESS)]
     [DataRow(">", TokenType.GREATER)]
     [DataRow("!", TokenType.BANG)]
+    [DataRow("(", TokenType.LEFT_PAREN)]
+    [DataRow(")", TokenType.RIGHT_PAREN)]
     public void Tokenize_SingleCharacterTokens_ReturnsExpectedTokens(string inputChar, TokenType expectedType)
     {
         var tokenizer = new Tokenizer();

--- a/dotnet/flx.SILQ/Core/Interpreter.Expression.cs
+++ b/dotnet/flx.SILQ/Core/Interpreter.Expression.cs
@@ -82,4 +82,14 @@ public partial class Interpreter : IVisitor<object>
         }
         return null;
     }
+
+    /// <summary>
+    /// Visits a <see cref="Grouping"/> expression and evaluates its contained expression.
+    /// </summary>
+    /// <param name="grouping">The grouping expression to evaluate.</param>
+    /// <returns>The result of the evaluated grouping expression.</returns>
+    public object Visit(Grouping grouping)
+    {
+       return Evaluate(grouping.Expression);
+    }
 }

--- a/dotnet/flx.SILQ/Core/Parser.Base.cs
+++ b/dotnet/flx.SILQ/Core/Parser.Base.cs
@@ -5,5 +5,44 @@ using flx.SILQ.Models;
 namespace flx.SILQ.Core;
 
 public partial class Parser
-{ 
+{
+    private bool Match(params TokenType[] types)
+    {
+        foreach (var type in types)
+        {
+            if (Check(type))
+            {
+                Advance();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private Token Advance()
+    {
+        if (!IsAtEnd()) _current++;
+        return Previous();
+    }
+
+    private Token Previous()
+    {
+        return _tokens[_current - 1];
+    }
+
+    private bool IsAtEnd()
+    {
+        return Peek().TokenType == TokenType.EOF;
+    }
+
+    private bool Check(TokenType type)
+    {
+        if (IsAtEnd()) return false;
+        return Peek().TokenType == type;
+    }
+
+    private Token Peek()
+    {
+        return _tokens[_current];
+    }
 }

--- a/dotnet/flx.SILQ/Core/Parser.Expression.cs
+++ b/dotnet/flx.SILQ/Core/Parser.Expression.cs
@@ -116,6 +116,13 @@ public partial class Parser
 
         if (Match(TokenType.IDENTIFIER)) throw new ParserError(Peek(), "Identifier not implemented yet");
 
+        if (Match(TokenType.LEFT_PAREN))
+        {
+            var expression = Expression();
+            if (!Match(TokenType.RIGHT_PAREN)) throw new ParserError(Peek(), "Expected ')' after expression");
+            return new Grouping(expression);
+        }
+
         throw new ParserError(Peek(), "Expected expression");
 
     }

--- a/dotnet/flx.SILQ/Core/Parser.Expression.cs
+++ b/dotnet/flx.SILQ/Core/Parser.Expression.cs
@@ -119,44 +119,4 @@ public partial class Parser
         throw new ParserError(Peek(), "Expected expression");
 
     }
-
-    private bool Match(params TokenType[] types)
-    {
-        foreach (var type in types)
-        {
-            if (Check(type))
-            {
-                Advance();
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private Token Advance()
-    {
-        if (!IsAtEnd()) _current++;
-        return Previous();
-    }
-
-    private Token Previous()
-    {
-        return _tokens[_current - 1];
-    }
-
-    private bool IsAtEnd()
-    {
-        return Peek().TokenType == TokenType.EOF;
-    }
-
-    private bool Check(TokenType type)
-    {
-        if (IsAtEnd()) return false;
-        return Peek().TokenType == type;
-    }
-
-    private Token Peek()
-    {
-        return _tokens[_current];
-    }
 }

--- a/dotnet/flx.SILQ/Core/Tokenizer.cs
+++ b/dotnet/flx.SILQ/Core/Tokenizer.cs
@@ -52,6 +52,12 @@ public class Tokenizer
                 case '\t':
                 case '\n':
                     break;
+                case '(':
+                    tokens.Add(new Token(TokenType.LEFT_PAREN, c.Value.ToString(), null, c.Line, c.Column));
+                    break;
+                case ')':
+                    tokens.Add(new Token(TokenType.RIGHT_PAREN, c.Value.ToString(), null, c.Line, c.Column));
+                    break;
                 case '.':
                     tokens.Add(new Token(TokenType.DOT, c.Value.ToString(), null, c.Line, c.Column));
                     break;

--- a/dotnet/flx.SILQ/Expressions/Grouping.cs
+++ b/dotnet/flx.SILQ/Expressions/Grouping.cs
@@ -1,0 +1,6 @@
+namespace flx.SILQ.Expressions;
+
+public record Grouping(Expression Expression) : Expression
+{
+    public override T Accept<T>(IVisitor<T> visitor) => visitor.Visit(this);
+}

--- a/dotnet/flx.SILQ/Expressions/IVisitor.cs
+++ b/dotnet/flx.SILQ/Expressions/IVisitor.cs
@@ -5,4 +5,5 @@ public interface IVisitor<T>
     T Visit(Literal literal);
     T Visit(Unary unary);
     T Visit(Binary binary);
+    T Visit(Grouping grouping);
 }

--- a/dotnet/flx.SILQ/Models/TokenType.cs
+++ b/dotnet/flx.SILQ/Models/TokenType.cs
@@ -96,6 +96,11 @@ public enum TokenType
     LAST,
 
     /// <summary>
+    /// Left brace '('
+    /// </summary>
+    LEFT_PAREN,
+
+    /// <summary>
     /// Less '<'
     /// </summary>
     LESS,
@@ -144,6 +149,11 @@ public enum TokenType
     /// 'print' keyword
     /// </summary>
     PRINT,
+
+    /// <summary>
+    /// Right brace ')'
+    /// </summary>
+    RIGHT_PAREN,
 
     /// <summary>
     /// 'select' keyword


### PR DESCRIPTION
Introduce grouping expressions in the parser and interpreter, enabling nested evaluations. Refactor code for clarity and add corresponding tests to ensure functionality.