### PR TITLE
Add support for "As" statement in parser and interpreter

### DIFF
--- a/dotnet/flx.SILQ.Tests/InterpreterTests.cs
+++ b/dotnet/flx.SILQ.Tests/InterpreterTests.cs
@@ -353,7 +353,7 @@ public class InterpreterTests
     }
 
     [TestMethod]
-    public void Interpret_WhenFromStatementWithIdentifier_ReturnsResult()
+    public void Interpret_WhenFromStatement_ReturnsResult()
     {
         // Arrange
         var variable = new Variable(new Token(TokenType.IDENTIFIER, "myTable", null, 1));
@@ -369,7 +369,7 @@ public class InterpreterTests
     }
 
     [TestMethod]
-    public void Interpret_WhenWhereStatementWithCondition_ReturnsResult()
+    public void Interpret_WhenWhereStatement_ReturnsResult()
     {
         // Arrange
         var condition = new Literal(true);
@@ -399,5 +399,20 @@ public class InterpreterTests
 
         // Assert
         throw new NotImplementedException("Assertion for Select statement result is not implemented.");
+    }
+
+    [TestMethod]
+    public void Interpret_WhenAsStatement_ReturnsResult()
+    {
+        // Arrange
+        var name = new Token(TokenType.IDENTIFIER, "myAlias", null, 1);
+        var asStatement = new As(name);
+        var interpreter = new Interpreter();
+
+        // Act
+        interpreter.Interpret([asStatement]);
+
+        // Assert
+        throw new NotImplementedException("Assertion for As statement result is not implemented.");
     }
 }

--- a/dotnet/flx.SILQ.Tests/ParserTests.cs
+++ b/dotnet/flx.SILQ.Tests/ParserTests.cs
@@ -620,4 +620,29 @@ public class ParserTests
         Assert.IsInstanceOfType(selectStatement.Expressions[0], typeof(Variable));
         Assert.IsInstanceOfType(selectStatement.Expressions[1], typeof(Variable));
     }
+
+    [TestMethod]
+    public void ParseStatement_WhenAsStatement_ReturnsAsStatement()
+    {
+        // Arrange
+        var tokens = new List<Token>
+        {
+            new Token(TokenType.AS, "as", null, 1),
+            new Token(TokenType.IDENTIFIER, "myVar", null, 1),
+            new Token(TokenType.SEMICOLON, ";", null, 1),
+            new Token(TokenType.EOF, null, null, 1)
+        };
+
+        // Act
+        var parser = new Parser();
+        var statements = parser.ParseStatements(tokens);
+
+        // Assert
+        Assert.IsNotNull(statements);
+        Assert.IsInstanceOfType(statements.First(), typeof(As));
+
+        var asStatement = (As)statements.First();
+        Assert.IsNotNull(asStatement.Name);
+        Assert.AreEqual("myVar", asStatement.Name.Lexeme);
+    }
 }

--- a/dotnet/flx.SILQ/Core/Interpreter.Statement.cs
+++ b/dotnet/flx.SILQ/Core/Interpreter.Statement.cs
@@ -46,4 +46,13 @@ public partial class Interpreter : IVisitor
     {
         throw new NotImplementedException();
     }
+
+    /// <summary>
+    /// Implements the visitor method for the <see cref="As"/> statement.
+    /// </summary>
+    /// <param name="statement">The "As" statement to process.</param>
+    public void Visit(As statement)
+    {
+        throw new NotImplementedException();
+    }
 }

--- a/dotnet/flx.SILQ/Core/Parser.Statement.cs
+++ b/dotnet/flx.SILQ/Core/Parser.Statement.cs
@@ -46,6 +46,7 @@ public partial class Parser
         if (Match(TokenType.FROM)) return From();
         if (Match(TokenType.WHERE)) return Where();
         if (Match(TokenType.SELECT)) return Select();
+        if (Match(TokenType.AS)) return As();
 
         throw new ParserError(Peek(), "Expect statement.");
     }
@@ -101,5 +102,11 @@ public partial class Parser
         Consume(TokenType.RIGHT_BRACE, "Expect '}' after expression.");
 
         return new Select([.. expressions]);
+    }
+
+    private Statement As()
+    {
+        Token name = Consume(TokenType.IDENTIFIER, "Expect identifier after 'as'.");
+        return new As(name);
     }
 }

--- a/dotnet/flx.SILQ/Statements/As.cs
+++ b/dotnet/flx.SILQ/Statements/As.cs
@@ -1,0 +1,22 @@
+using flx.SILQ.Models;
+
+namespace flx.SILQ.Statements;
+
+/// <summary>
+/// Represents an 'As' statement in the SILQ language.
+/// </summary>
+/// <remarks>
+/// This statement is used to define a specific behavior or operation in the SILQ language.
+/// It inherits from the base <see cref="Statement"/> class and implements the <see cref="IVisitor"/> pattern.
+/// </remarks>
+public record As(Token Name) : Statement
+{
+    /// <summary>
+    /// Accepts a visitor that implements the <see cref="IVisitor"/> interface.
+    /// </summary>
+    /// <param name="visitor">The visitor to accept.</param>
+    public override void Accept(IVisitor visitor)
+    {
+        visitor.Visit(this);
+    }
+}

--- a/dotnet/flx.SILQ/Statements/IVisitor.cs
+++ b/dotnet/flx.SILQ/Statements/IVisitor.cs
@@ -9,24 +9,30 @@ public interface IVisitor
     /// <summary>
     /// Visits a <see cref="Print"/> statement node.
     /// </summary>
-    /// <param name="print">The print statement to visit.</param>
-    void Visit(Print print);
+    /// <param name="statement">The print statement to visit.</param>
+    void Visit(Print statement);
 
     /// <summary>
     /// Visits a <see cref="From"/> statement node.
     /// </summary>
-    /// <param name="from">The from statement to visit.</param>
-    void Visit(From from);
+    /// <param name="statement">The from statement to visit.</param>
+    void Visit(From statement);
 
     /// <summary>
     /// Visits a <see cref="Where"/> statement node.
     /// </summary>
-    /// <param name="where">The where statement to visit.</param>
-    void Visit(Where where);
+    /// <param name="statement">The where statement to visit.</param>
+    void Visit(Where statement);
 
     /// <summary>
     /// Visits a <see cref="Select"/> statement node.
     /// </summary>
-    /// <param name="select">The select statement to visit.</param>
-    void Visit(Select select);
+    /// <param name="statement">The select statement to visit.</param>
+    void Visit(Select statement);
+
+    /// <summary>
+    /// Visits a <see cref="As"/> statement node.
+    /// </summary>
+    /// <param name="statement">The as statement to visit.</param>
+    void Visit(As statement);
 }


### PR DESCRIPTION
Introduce functionality for parsing and interpreting the "As" statement in the SILQ language, including necessary tests and visitor pattern implementation.