### PR TITLE
Add logical `and` and `or` expression support

### DIFF
--- a/dotnet/flx.SILQ.Tests/Core/InterpreterTests.cs
+++ b/dotnet/flx.SILQ.Tests/Core/InterpreterTests.cs
@@ -337,6 +337,74 @@ public class InterpreterTests
     }
 
     [TestMethod]
+    public void Interpret_WhenOrFalseyExpression_ReturnsResult()
+    {
+        // Arrange
+        var left = new Literal(false);
+        var op = new Token(TokenType.OR, "or", null, 1);
+        var right = new Literal(true);
+        var expr = new Logical(left, op, right);
+        var interpreter = new Interpreter("context");
+
+        // Act
+        var result = interpreter.Interpret(expr);
+
+        // Assert
+        Assert.AreEqual("true", result);
+    }
+
+    [TestMethod]
+    public void Interpret_WhenOrTruthyExpression_ReturnsResult()
+    {
+        // Arrange
+        var left = new Literal(true);
+        var op = new Token(TokenType.OR, "or", null, 1);
+        var right = new Literal(false);
+        var expr = new Logical(left, op, right);
+        var interpreter = new Interpreter("context");
+
+        // Act
+        var result = interpreter.Interpret(expr);
+
+        // Assert
+        Assert.AreEqual("true", result);
+    }
+
+    [TestMethod]
+    public void Interpret_WhenAndFalseyExpression_ReturnsResult()
+    {
+        // Arrange
+        var left = new Literal(true);
+        var op = new Token(TokenType.AND, "and", null, 1);
+        var right = new Literal(false);
+        var expr = new Logical(left, op, right);
+        var interpreter = new Interpreter("context");
+
+        // Act
+        var result = interpreter.Interpret(expr);
+
+        // Assert
+        Assert.AreEqual("false", result);
+    }
+
+    [TestMethod]
+    public void Interpret_WhenAndTruthyExpression_ReturnsResult()
+    {
+        // Arrange
+        var left = new Literal(true);
+        var op = new Token(TokenType.AND, "and", null, 1);
+        var right = new Literal(true);
+        var expr = new Logical(left, op, right);
+        var interpreter = new Interpreter("context");
+
+        // Act
+        var result = interpreter.Interpret(expr);
+
+        // Assert
+        Assert.AreEqual("true", result);
+    }
+
+    [TestMethod]
     public void Interpret_WhenPrintStatement_ReturnsResult()
     {
         // Arrange

--- a/dotnet/flx.SILQ.Tests/Core/ParserTests.cs
+++ b/dotnet/flx.SILQ.Tests/Core/ParserTests.cs
@@ -561,6 +561,48 @@ public class ParserTests
     }
 
     [TestMethod]
+    public void ParseExpression_WhenAnd_ReturnsLogicalExpression()
+    {
+        // Arrange
+        var tokens = new List<Token>
+        {
+            new Token(TokenType.TRUE, "true", null, 1),
+            new Token(TokenType.AND, "and", null, 1),
+            new Token(TokenType.FALSE, "false", null, 1),
+            new Token(TokenType.EOF, null, null, 1)
+        };
+
+        // Act
+        var parser = new Parser();
+        var expression = parser.ParseExpression(tokens);
+
+        // Assert
+        Assert.IsNotNull(expression);
+        Assert.IsInstanceOfType(expression, typeof(Logical));
+    }
+
+    [TestMethod]
+    public void ParseExpression_WhenOr_ReturnsLogicalExpression()
+    {
+        // Arrange
+        var tokens = new List<Token>
+        {
+            new Token(TokenType.TRUE, "true", null, 1),
+            new Token(TokenType.OR, "or", null, 1),
+            new Token(TokenType.FALSE, "false", null, 1),
+            new Token(TokenType.EOF, null, null, 1)
+        };
+
+        // Act
+        var parser = new Parser();
+        var expression = parser.ParseExpression(tokens);
+
+        // Assert
+        Assert.IsNotNull(expression);
+        Assert.IsInstanceOfType(expression, typeof(Logical));
+    }
+
+    [TestMethod]
     public void ParseStatement_WhenPrintStatement_ReturnsPrintStatement()
     {
         // Arrange

--- a/dotnet/flx.SILQ.Tests/Core/ParserTests.cs
+++ b/dotnet/flx.SILQ.Tests/Core/ParserTests.cs
@@ -299,7 +299,7 @@ public class ParserTests
 
         // Assert
         Assert.IsNotNull(expression);
-        Assert.IsInstanceOfType(expression, typeof(Literal));
+        Assert.IsInstanceOfType(expression, typeof(Logical));
     }
 
     [TestMethod]
@@ -320,7 +320,7 @@ public class ParserTests
 
         // Assert
         Assert.IsNotNull(expression);
-        Assert.IsInstanceOfType(expression, typeof(Literal));
+        Assert.IsInstanceOfType(expression, typeof(Logical));
     }
 
     [TestMethod]

--- a/dotnet/flx.SILQ/Core/Interpreter.Expression.cs
+++ b/dotnet/flx.SILQ/Core/Interpreter.Expression.cs
@@ -114,4 +114,14 @@ public partial class Interpreter : IVisitor<object>
     {
         throw new NotImplementedException();
     }
+
+    /// <summary>
+    /// Visits a <see cref="Logical"/> expression and evaluates it according to its operator and operands.
+    /// </summary>
+    /// <param name="logical">The logical expression to evaluate.</param>
+    /// <returns>The result of the logical operation.</returns>
+    public object Visit(Logical logical)
+    {
+        throw new NotImplementedException();
+    }
 }

--- a/dotnet/flx.SILQ/Core/Interpreter.Expression.cs
+++ b/dotnet/flx.SILQ/Core/Interpreter.Expression.cs
@@ -91,7 +91,7 @@ public partial class Interpreter : IVisitor<object>
     /// <returns>The result of the evaluated grouping expression.</returns>
     public object Visit(Grouping grouping)
     {
-       return Evaluate(grouping.Expression);
+        return Evaluate(grouping.Expression);
     }
 
     /// <summary>
@@ -122,6 +122,17 @@ public partial class Interpreter : IVisitor<object>
     /// <returns>The result of the logical operation.</returns>
     public object Visit(Logical logical)
     {
-        throw new NotImplementedException();
+        object left = Evaluate(logical.Left);
+
+        if (logical.Op.TokenType == TokenType.OR)
+        {
+            if (IsTruthy(left)) return left;
+        }
+        else
+        {
+            if (!IsTruthy(left)) return left;
+        }
+
+        return Evaluate(logical.Right);
     }
 }

--- a/dotnet/flx.SILQ/Core/Parser.Expression.cs
+++ b/dotnet/flx.SILQ/Core/Parser.Expression.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Reflection.Metadata;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using flx.SILQ.Errors;
@@ -42,7 +43,42 @@ public partial class Parser
     /// <returns>The parsed <see cref="Expression"/>.</returns>
     private Expression Expression()
     {
-        return Equality();
+        return Or();
+    }
+
+    /// <summary>
+    /// Parses logical OR expressions.
+    /// </summary>
+    /// <returns>The parsed <see cref="Expression"/>.</returns>
+    private Expression Or(){
+        Expression expression = And();
+
+        while (Match(TokenType.OR))
+        {
+            var operatorToken = Previous();
+            var right = And();
+            expression = new Logical(expression, operatorToken, right);
+        }
+
+        return expression;
+    }
+
+    /// <summary>
+    /// Parses logical AND expressions.
+    /// </summary>
+    /// <returns>The parsed <see cref="Expression"/>.</returns>
+    private Expression And()
+    {
+        Expression expression = Equality();
+
+        while (Match(TokenType.AND))
+        {
+            var operatorToken = Previous();
+            var right = Equality();
+            expression = new Logical(expression, operatorToken, right);
+        }
+
+        return expression;
     }
 
     /// <summary>

--- a/dotnet/flx.SILQ/Expressions/IVisitor.cs
+++ b/dotnet/flx.SILQ/Expressions/IVisitor.cs
@@ -8,4 +8,5 @@ public interface IVisitor<T>
     T Visit(Grouping grouping);
     T Visit(Variable variable);
     T Visit(Function function);
+    T Visit(Logical logical);
 }

--- a/dotnet/flx.SILQ/Expressions/Logical.cs
+++ b/dotnet/flx.SILQ/Expressions/Logical.cs
@@ -1,0 +1,11 @@
+using flx.SILQ.Models;
+
+namespace flx.SILQ.Expressions;
+
+public record Logical(Expression Left, Token Op, Expression right) : Expression
+{
+    public override T Accept<T>(IVisitor<T> visitor)
+    {
+        return visitor.Visit(this);
+    }
+}

--- a/dotnet/flx.SILQ/Expressions/Logical.cs
+++ b/dotnet/flx.SILQ/Expressions/Logical.cs
@@ -2,7 +2,7 @@ using flx.SILQ.Models;
 
 namespace flx.SILQ.Expressions;
 
-public record Logical(Expression Left, Token Op, Expression right) : Expression
+public record Logical(Expression Left, Token Op, Expression Right) : Expression
 {
     public override T Accept<T>(IVisitor<T> visitor)
     {


### PR DESCRIPTION
Introduce parsing and evaluation for logical `and` and `or` expressions in the interpreter, enhancing the expression handling capabilities.