### PR TITLE
Add DefineGlobal method and support for `as` statement in interpreter

### DIFF
--- a/dotnet/flx.SILQ.Tests/Core/EnvironmentTests.cs
+++ b/dotnet/flx.SILQ.Tests/Core/EnvironmentTests.cs
@@ -271,4 +271,89 @@ public class EnvironmentTests
         // Assert
         Assert.AreEqual(100, environment.Get(name));
     }
+
+    [TestMethod]
+    public void DefineGlobal_WhenNameIsNull_ThrowsRuntimeError()
+    {
+        // Arrange
+        var environment = new SILQ.Core.Environment();
+
+        // Act
+        Action action = () => environment.DefineGlobal(null, null);
+
+        // Act & Assert
+        Assert.ThrowsException<RuntimeError>(action);
+    }
+
+    [TestMethod]
+    public void DefineGlobal_WhenNameIsEmpty_ThrowsRuntimeError()
+    {
+        // Arrange
+        var environment = new SILQ.Core.Environment();
+
+        // Act
+        Action action = () => environment.DefineGlobal(string.Empty, null);
+
+        // Act & Assert
+        Assert.ThrowsException<RuntimeError>(action);
+    }
+
+    [TestMethod]
+    public void DefineGlobal_WhenNameIsWhitespace_ThrowsRuntimeError()
+    {
+        // Arrange
+        var environment = new SILQ.Core.Environment();
+
+        // Act
+        Action action = () => environment.DefineGlobal("   ", null);
+
+        // Act & Assert
+        Assert.ThrowsException<RuntimeError>(action);
+    }
+
+    [TestMethod]
+    public void DefineGlobal_WhenNameIsUndefined_ThrowsRuntimeError()
+    {
+        // Arrange
+        var environment = new SILQ.Core.Environment();
+        var name = "testVar";
+
+        // Act
+        Action action = () => environment.DefineGlobal(name, null);
+
+        // Act & Assert
+        Assert.ThrowsException<RuntimeError>(action);
+    }
+
+    [TestMethod]
+    public void DefineGlobal_WhenGlobalContext_VariableIsDefined()
+    {
+        // Arrange
+        var environment = new SILQ.Core.Environment();
+        var name = "testVar";
+        var value = 42;
+
+        // Act
+        environment.DefineGlobal(name, value);
+
+        // Assert
+        Assert.AreEqual(value, environment.Get(name));
+    }
+
+    [TestMethod]
+    public void DefineGlobal_WhenNestedContext_VariableIsDefined()
+    {
+        // Arrange
+        var parentEnvironment = new SILQ.Core.Environment();
+        var childEnvironment = new SILQ.Core.Environment(parentEnvironment);
+        var name = "testVar";
+        var value = 42;
+
+        // Act
+        childEnvironment.DefineGlobal(name, value);
+
+        // Assert
+        Assert.AreEqual(value, childEnvironment.Get(name));
+        Assert.AreEqual(value, parentEnvironment.Get(name));
+    }
 }

--- a/dotnet/flx.SILQ.Tests/RuntimeTests.cs
+++ b/dotnet/flx.SILQ.Tests/RuntimeTests.cs
@@ -287,4 +287,17 @@ public class RuntimeTests
         // Assert
         Assert.ThrowsException<RuntimeError>(action);
     }
+
+    [TestMethod]
+    public void Execute_WhenFromAs_ReturnsNull(){
+        // Arrange
+        var query = "from School.Students as Student;";
+
+        // Act
+        var runtime = new Runtime(_testContext);
+        var result = runtime.Execute(query);
+
+        // Assert
+        Assert.IsNull(result);
+    }
 }

--- a/dotnet/flx.SILQ/Core/Environment.cs
+++ b/dotnet/flx.SILQ/Core/Environment.cs
@@ -53,9 +53,9 @@ public class Environment
     public void Define(string name, object value)
     {
         if (string.IsNullOrEmpty(name)) throw new RuntimeError(name, "Variable name cannot be null or empty.");
-        if(string.IsNullOrWhiteSpace(name)) throw new RuntimeError(name, "Variable name cannot be empty or whitespace.");
+        if (string.IsNullOrWhiteSpace(name)) throw new RuntimeError(name, "Variable name cannot be empty or whitespace.");
         if (name == "context") throw new RuntimeError(name, "The identifier 'context' is reserved and cannot be used.");
-        if(_variables.ContainsKey(name)) throw new RuntimeError(name, $"The identifier '{name}' is already defined in the current context.");
+        if (_variables.ContainsKey(name)) throw new RuntimeError(name, $"The identifier '{name}' is already defined in the current context.");
 
         _variables[name] = value;
     }
@@ -99,6 +99,28 @@ public class Environment
         }
 
         throw new RuntimeError(name, $"Undefined variable '{name}'.");
+    }
+
+    /// <summary>
+    /// Defines a global variable in the environment.
+    /// </summary>
+    /// <param name="name">The name of the variable to define.</param>
+    /// <param name="value">The value to assign to the variable.</param>
+    /// <exception cref="RuntimeError">Thrown if the variable name is null, empty or whitespace.</exception>
+    /// <exception cref="RuntimeError">Thrown if the value is null.</exception>
+    public void DefineGlobal(string name, object value)
+    {
+        if (string.IsNullOrEmpty(name)) throw new RuntimeError(name, "Variable name cannot be null or empty.");
+        if (string.IsNullOrWhiteSpace(name)) throw new RuntimeError(name, "Variable name cannot be empty or whitespace.");
+        if (value == null) throw new RuntimeError(name, "Value cannot be null.");
+
+        if (Enclosing != null)
+        {
+            Enclosing.DefineGlobal(name, value);
+            return;
+        }
+
+        Define(name, value);
     }
 }
 

--- a/dotnet/flx.SILQ/Core/Environment.cs
+++ b/dotnet/flx.SILQ/Core/Environment.cs
@@ -110,8 +110,7 @@ public class Environment
     /// <exception cref="RuntimeError">Thrown if the value is null.</exception>
     public void DefineGlobal(string name, object value)
     {
-        if (string.IsNullOrEmpty(name)) throw new RuntimeError(name, "Variable name cannot be null or empty.");
-        if (string.IsNullOrWhiteSpace(name)) throw new RuntimeError(name, "Variable name cannot be empty or whitespace.");
+        if (string.IsNullOrWhiteSpace(name)) throw new RuntimeError(name, "Variable name cannot be null, empty, or whitespace.");
         if (value == null) throw new RuntimeError(name, "Value cannot be null.");
 
         if (Enclosing != null)

--- a/dotnet/flx.SILQ/Core/Interpreter.Statement.cs
+++ b/dotnet/flx.SILQ/Core/Interpreter.Statement.cs
@@ -32,17 +32,19 @@ public partial class Interpreter : IVisitor
     public object Visit(From from)
     {
         var context = _environment.Get("context");
-        var result = ResolveVariable(from.Property, context);
+        var variable = ResolveVariable(from.Property, context);
 
         if (from.Statement is not null)
         {
             var environment = new Environment(_environment);
-            environment.SetContext(result);
+            environment.SetContext(variable);
             _environment = environment;
-            return Execute(from.Statement);
+            var result = Execute(from.Statement);
+            _environment = _environment.Enclosing;
+            return result;
         }
 
-        return result;
+        return variable;
     }
 
     /// <summary>
@@ -90,7 +92,10 @@ public partial class Interpreter : IVisitor
     /// <param name="statement">The "As" statement to process.</param>
     public void Visit(As statement)
     {
-        throw new NotImplementedException();
+        var context = _environment.Get("context");
+        if (context == null) throw new RuntimeError("As", "Context is null.");
+
+        _environment.DefineGlobal(statement.Name.Lexeme, context);
     }
 
     /// <summary>


### PR DESCRIPTION
Introduce the DefineGlobal method to the Environment class with error handling for invalid variable names and values. Enhance the interpreter to support the `as` statement, allowing context variables to be defined globally. Update tests to ensure proper functionality and error handling.