### PR TITLE
Add SelectObject class and enhance Select statement handling in interpreter

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -24,4 +24,4 @@ jobs:
       - name: Pack
         run: dotnet pack ${{ env.SOLUTION_PATH }} --configuration Release --no-restore
       - name: Publish to NuGet
-        run: dotnet nuget push dotnet/flx.SILQ/bin/Release/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }} 
+        run: dotnet nuget push dotnet/flx.SILQ/bin/Release/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate

--- a/dotnet/flx.SILQ.Tests/RuntimeTests.cs
+++ b/dotnet/flx.SILQ.Tests/RuntimeTests.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using flx.SILQ.Errors;
+using flx.SILQ.Models;
 
 namespace flx.SILQ.Tests;
 
@@ -127,7 +128,8 @@ public class RuntimeTests
     }
 
     [TestMethod]
-    public void Execute_WhenFromWhereAnd_ReturnsList(){
+    public void Execute_WhenFromWhereAnd_ReturnsList()
+    {
         // Arrange
         var query = "from School.Students where Age == 14 and Grade == \"9th\";";
 
@@ -142,7 +144,8 @@ public class RuntimeTests
     }
 
     [TestMethod]
-    public void Execute_WhenFromWhereOr_ReturnsList(){
+    public void Execute_WhenFromWhereOr_ReturnsList()
+    {
         // Arrange
         var query = "from School.Students where Name == \"Alice\" or Grade == \"10th\";";
 
@@ -289,7 +292,8 @@ public class RuntimeTests
     }
 
     [TestMethod]
-    public void Execute_WhenFromAs_ReturnsNull(){
+    public void Execute_WhenFromAs_ReturnsNull()
+    {
         // Arrange
         var query = "from School.Students as Student;";
 
@@ -299,5 +303,87 @@ public class RuntimeTests
 
         // Assert
         Assert.IsNull(result);
+    }
+
+    [TestMethod]
+    public void Execute_WhenFromSelectListSingle_ReturnsList()
+    {
+        // Arrange
+        var query = "from School.Students select { Name };";
+
+        // Act
+        var runtime = new Runtime(_testContext);
+        var result = runtime.Execute(query);
+
+        // Assert
+        Assert.IsNotNull(result);
+        Assert.IsInstanceOfType(result, typeof(IList));
+
+        var list = (List<object>)result;
+        Assert.AreEqual(3, list.Count);
+        Assert.IsInstanceOfType(list[0], typeof(SelectObject));
+
+        dynamic so = (SelectObject)list[0];
+        Assert.AreEqual("Alice", so.Name);
+    }
+
+    [TestMethod]
+    public void Execute_WhenFromSelectListMultiple_ReturnsList()
+    {
+        // Arrange
+        var query = "from School.Students select { Name, Age };";
+
+        // Act
+        var runtime = new Runtime(_testContext);
+        var result = runtime.Execute(query);
+
+        // Assert
+        Assert.IsNotNull(result);
+        Assert.IsInstanceOfType(result, typeof(IList));
+
+        var list = (List<object>)result;
+        Assert.AreEqual(3, list.Count);
+        Assert.IsInstanceOfType(list[0], typeof(SelectObject));
+
+        dynamic so = (SelectObject)list[0];
+        Assert.AreEqual("Alice", so.Name);
+        Assert.AreEqual(14, so.Age);
+    }
+
+    [TestMethod]
+    public void Execute_WhenFromSelectObjectSingle_ReturnObject()
+    {
+        // Arrange
+        var query = "from School select { Name };";
+
+        // Act
+        var runtime = new Runtime(_testContext);
+        var result = runtime.Execute(query);
+
+        // Assert
+        Assert.IsNotNull(result);
+        Assert.IsInstanceOfType(result, typeof(SelectObject));
+
+        dynamic so = (SelectObject)result;
+        Assert.AreEqual("Test School", so.Name);
+    }
+
+    [TestMethod]
+    public void Execute_WhenFromSelectObjectMultiple_ReturnObject()
+    {
+        // Arrange
+        var query = "from School select { Name, Address };";
+
+        // Act
+        var runtime = new Runtime(_testContext);
+        var result = runtime.Execute(query);
+
+        // Assert
+        Assert.IsNotNull(result);
+        Assert.IsInstanceOfType(result, typeof(SelectObject));
+
+        dynamic so = (SelectObject)result;
+        Assert.AreEqual("Test School", so.Name);
+        Assert.AreEqual("123 Test St", so.Address);
     }
 }

--- a/dotnet/flx.SILQ.Tests/models/SelectObjectTests.cs
+++ b/dotnet/flx.SILQ.Tests/models/SelectObjectTests.cs
@@ -1,0 +1,140 @@
+using System.Collections.Generic;
+using System.Dynamic;
+using flx.SILQ.Errors;
+using flx.SILQ.Models;
+
+namespace flx.SILQ.Tests.Models
+{
+    [TestClass]
+    public class SelectObjectTests
+    {
+        [TestMethod]
+        public void Constructor_WithDictionary_SetsProperties()
+        {
+            // Arrange
+            var dict = new Dictionary<string, object> { { "Name", "Alice" }, { "Age", 30 } };
+
+            // Act
+            dynamic obj = new SelectObject(dict);
+
+            // Assert
+            Assert.AreEqual("Alice", obj.Name);
+            Assert.AreEqual(30, obj.Age);
+        }
+
+        [TestMethod]
+        public void Constructor_WithSingleProperty_SetsProperty()
+        {
+            // Arrange
+            var name = "City";
+            var value = "London";
+
+            // Act
+            dynamic obj = new SelectObject(name, value);
+
+            // Assert
+            Assert.AreEqual("London", obj.City);
+        }
+
+        [TestMethod]
+        public void TrySetMember_AddsOrUpdatesProperty()
+        {
+            // Arrange
+            var name = "Country";
+            var value = "UK";
+
+            // Act
+            dynamic obj = new SelectObject(name, value);
+            obj.Country = "Germany";
+
+            // Assert
+            Assert.AreEqual("Germany", obj.Country);
+        }
+
+        [TestMethod]
+        public void TryGetMember_ReturnsNullIfNotFound()
+        {
+            // Arrange
+            dynamic obj = new SelectObject("Foo", 123);
+            object value = null;
+            var binder = new TestGetMemberBinder("Bar");
+
+            // Act
+            bool found = ((DynamicObject)obj).TryGetMember(binder, out value);
+
+            // Assert
+            Assert.IsFalse(found);
+            Assert.IsNull(value);
+        }
+
+        [TestMethod]
+        public void TryGetMember_ReturnsValueIfFound()
+        {
+            // Arrange
+            var dict = new Dictionary<string, object> { { "Name", "Alice" }, { "Age", 30 } };
+            dynamic obj = new SelectObject(dict);
+            object value = null;
+            var binder = new TestGetMemberBinder("Name");
+
+            // Act
+            bool found = ((DynamicObject)obj).TryGetMember(binder, out value);
+
+            // Assert
+            Assert.IsTrue(found);
+            Assert.AreEqual("Alice", value);
+        }
+
+                [TestMethod]
+        public void GetMemeber_ReturnsValue_WhenPropertyExists()
+        {
+            // Arrange
+            var dict = new Dictionary<string, object> { { "Foo", 42 } };
+            var obj = new SelectObject(dict);
+
+            // Act
+            var value = obj.GetMemeber("Foo");
+
+            // Assert
+            Assert.AreEqual(42, value);
+        }
+
+        [TestMethod]
+        public void GetMemeber_Throws_WhenNameIsNullOrEmptyOrWhitespace()
+        {
+            // Arrange
+            var obj = new SelectObject("Bar", 123);
+
+            // Act & Assert
+            Assert.ThrowsException<RuntimeError>(() => obj.GetMemeber(null));
+            Assert.ThrowsException<RuntimeError>(() => obj.GetMemeber(""));
+            Assert.ThrowsException<RuntimeError>(() => obj.GetMemeber("   "));
+        }
+
+        [TestMethod]
+        public void GetMemeber_Throws_WhenNameContainsDot()
+        {
+            // Arrange
+            var obj = new SelectObject("Baz", 1);
+
+            // Act & Assert
+            Assert.ThrowsException<RuntimeError>(() => obj.GetMemeber("Baz.Qux"));
+        }
+
+        [TestMethod]
+        public void GetMemeber_Throws_WhenPropertyNotFound()
+        {
+            // Arrange
+            var obj = new SelectObject("X", 99);
+
+            // Act & Assert
+            Assert.ThrowsException<RuntimeError>(() => obj.GetMemeber("Y"));
+        }
+
+        // Helper binder for testing TryGetMember
+        private class TestGetMemberBinder : GetMemberBinder
+        {
+            public TestGetMemberBinder(string name) : base(name, false) { }
+            public override DynamicMetaObject FallbackGetMember(DynamicMetaObject target, DynamicMetaObject errorSuggestion) => null;
+        }
+    }
+}

--- a/dotnet/flx.SILQ/Core/Interpreter.Base.cs
+++ b/dotnet/flx.SILQ/Core/Interpreter.Base.cs
@@ -221,6 +221,9 @@ public partial class Interpreter
     /// <exception cref="RuntimeError">Thrown if the variable is not defined in the context.</exception>
     public object ResolveVariable(Variable variable, object context)
     {
+        var type = context.GetType();
+        if (IsList(context)) return ResolveList(variable, context);
+
         var property = context.GetType().GetProperty(variable.Name.Lexeme);
         if (property == null) throw new RuntimeError(variable.Name, $"The identifier '{variable.Name.Lexeme}' is not defined in the current context.");
 
@@ -234,6 +237,18 @@ public partial class Interpreter
         if (CanConvertToDouble(propertyValue)) propertyValue = Convert.ToDouble(propertyValue);
 
         return propertyValue;
+    }
+
+    private object ResolveList(Variable variable, object context)
+    {
+        var list = context as IList;
+        var result = new List<object>();
+
+        foreach (var item in list)
+        {
+            result.Add(ResolveVariable(variable, item));
+        }
+        return result;
     }
 
     public object GetContext()

--- a/dotnet/flx.SILQ/Models/SelectObject.cs
+++ b/dotnet/flx.SILQ/Models/SelectObject.cs
@@ -1,0 +1,79 @@
+using System.Collections.Generic;
+using System.Dynamic;
+using flx.SILQ.Errors;
+
+namespace flx.SILQ.Models;
+
+/// <summary>
+/// Represents a dynamic object used for SILQ select projections.
+/// <para>
+/// This class allows dynamic creation and access of properties at runtime, enabling flexible
+/// projection of fields in SILQ queries (e.g., <c>select { Name, Age }</c>).
+/// </para>
+/// </summary>
+public sealed class SelectObject : DynamicObject
+{
+    private readonly Dictionary<string, object> _properties = new();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SelectObject"/> class with the specified properties.
+    /// </summary>
+    /// <param name="properties">A dictionary of property names and values to initialize the object with.</param>
+    public SelectObject(Dictionary<string, object> properties)
+    {
+        _properties = properties;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SelectObject"/> class with a single property.
+    /// </summary>
+    /// <param name="name">The name of the property to add.</param>
+    /// <param name="value">The value of the property to add.</param>
+    public SelectObject(string name, object value)
+    {
+        _properties.Add(name, value);
+    }
+
+    /// <summary>
+    /// Gets the value of a property by name, with validation and error handling.
+    /// </summary>
+    /// <param name="name">The name of the property to retrieve. Must not be null, empty, whitespace, or contain a dot ('.').</param>
+    /// <returns>The value of the property if found.</returns>
+    /// <exception cref="RuntimeError">Thrown if the name is invalid or the property does not exist.</exception>
+    public object GetMemeber(string name)
+    {
+        if (string.IsNullOrEmpty(name) || string.IsNullOrWhiteSpace(name)) throw new RuntimeError("name", "Name cannot be null, empty, or whitespace");
+        if (name.Contains('.')) throw new RuntimeError("name", "Name cannot contain '.'");
+        if (!_properties.ContainsKey(name)) throw new RuntimeError("name", $"Property '{name}' not found");
+        return _properties[name];
+    }
+
+    /// <summary>
+    /// Attempts to get the value of a dynamic property.
+    /// </summary>
+    /// <param name="binder">Provides information about the member to get.</param>
+    /// <param name="result">The value of the property, if found.</param>
+    /// <returns>True if the property exists; otherwise, false.</returns>
+    public override bool TryGetMember(GetMemberBinder binder, out object result)
+    {
+        if (_properties.TryGetValue(binder.Name, out result))
+        {
+            return true;
+        }
+
+        result = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to set the value of a dynamic property.
+    /// </summary>
+    /// <param name="binder">Provides information about the member to set.</param>
+    /// <param name="value">The value to set for the property.</param>
+    /// <returns>Always returns true.</returns>
+    public override bool TrySetMember(SetMemberBinder binder, object value)
+    {
+        _properties[binder.Name] = value;
+        return true;
+    }
+}

--- a/dotnet/flx.SILQ/flx.SILQ.csproj
+++ b/dotnet/flx.SILQ/flx.SILQ.csproj
@@ -14,7 +14,7 @@
   <PropertyGroup>
     <PackageId>flx.SILQ</PackageId>
     <VersionPrefix>1.0.0</VersionPrefix>
-    <VersionSuffix>alpha.2</VersionSuffix>
+    <VersionSuffix>alpha.3</VersionSuffix>
     <Authors>Sandro Paetzold</Authors>
     <Company>Flexington</Company>
     <Description>flx.SILQ provides the core components for the SILQ language, including the interpreter, parser, tokenizer, and essential models for building and executing SILQ queries.</Description>


### PR DESCRIPTION
Introduce a new `SelectObject` class for dynamic property access and enhance the interpreter to handle list selections in `Select` statements. Additionally, add a `--skip-duplicate` option to the NuGet publish command in the CI workflow.